### PR TITLE
Double Extension

### DIFF
--- a/src/parameters.h
+++ b/src/parameters.h
@@ -22,7 +22,7 @@ constexpr int SEE_ORDERING_MARGIN = -100;
 
 constexpr int SE_MIN_DEPTH = 8;
 constexpr int SE_BETA_SCALE = 32;
-constexpr int SE_DOUBLE_MARGIN = 32;
+constexpr int SE_DOUBLE_MARGIN = 20;
 
 // constexpr int HIST_PRUNING_DEPTH = 7;
 // constexpr int HIST_PRUNING_MARGIN = -2048;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -325,7 +325,10 @@ namespace Search {
 				ss->excluded = Move::NO_MOVE;
 
 				if (seScore < sBeta) {
-					extension = 1; // Singular Extension
+					if (!isPV && seScore < sBeta - SE_DOUBLE_MARGIN)
+						extension = 2; // Double extension
+					else
+						extension = 1; // Singular Extension
 				}
 				else if (ttEntry->score >= beta)
 					extension = -2 + isPV;


### PR DESCRIPTION
Elo   | 5.76 +- 4.06 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 9896 W: 2451 L: 2287 D: 5158
Penta | [118, 1171, 2220, 1307, 132]
https://chess.n9x.co/test/1597/

Elo   | 12.10 +- 7.15 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.23 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2786 W: 679 L: 582 D: 1525
Penta | [17, 302, 668, 379, 27]
https://chess.n9x.co/test/1598/