### PR TITLE
move bad SEE moves down by 800k bench 2731637

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -63,7 +63,7 @@ namespace Search {
 		else if (to != PieceType::NONE) {
 			int hist = thread.getCapthist(thread.board, move);
 			int score = hist + MVV_VALUES[to];
-			return 500000 + score;
+			return 500000 + score - 800000 * !SEE(thread.board, move, -PawnValue);
 		}
 		else if (move == ss->killer){
 			return 400000;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -225,7 +225,8 @@ bool SEE(Board &board, Move &move, int margin){
 	Bitboard occupied = board.occ() ^ Bitboard::fromSquare(from) ^ Bitboard::fromSquare(to);
 	Color stm = board.sideToMove();
 	Bitboard attackers = attackersTo(board, to, occupied);
-	Bitboard stmAttackers, bb;
+	Bitboard stmAttackers = Bitboard(); 
+	Bitboard bb = Bitboard();
 	int res = 1;
 	while (true){
 		stm = ~stm;


### PR DESCRIPTION
Elo   | 69.06 +- 16.05 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 734 W: 283 L: 139 D: 312
Penta | [4, 42, 164, 120, 37]
https://chess.n9x.co/test/1629/