### PR TITLE
Update TT in Qsearch

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -247,6 +247,7 @@ namespace Search {
 				bestScore = score;
 				if (score > alpha){
 					alpha = score;
+					qBestMove = move;
 					ttFlag = TTFlag::EXACT;
 				}
 			}

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -208,6 +208,8 @@ namespace Search {
 
 		int bestScore = eval;
 		int moveCount = 0;
+		Move qBestMove = Move::NO_MOVE;
+		uint8_t ttFlag = TTFlag::FAIL_LOW;
 
 		Movelist moves;
 
@@ -245,14 +247,19 @@ namespace Search {
 				bestScore = score;
 				if (score > alpha){
 					alpha = score;
+					ttFlag = TTFlag::EXACT;
 				}
 			}
 			if (score >= beta){
+				ttFlag = TTFlag::BETA_CUT;
 				break;
 			}
 		}
 		if (!moveCount && inCheck)
 			return -MATE + ply;
+
+		ttEntry->updateEntry(thread.board.hash(), qBestMove, bestScore, std::clamp(rawStaticEval, -INFINITE, INFINITE), ttFlag, 0);
+
 		return bestScore;
 
 	}


### PR DESCRIPTION
Elo   | 3.22 +- 2.57 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 22090 W: 4834 L: 4629 D: 12627
Penta | [197, 2569, 5321, 2748, 210]
https://chess.n9x.co/test/1764/