### PR TITLE
Clamp LMR depth

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -569,7 +569,9 @@ namespace Search {
 
 				reduction /= 1024;
 
-				score = -search<false>(newDepth - reduction, ply+1, -alpha - 1, -alpha, ss+1, thread, limit);
+				int lmrDepth = std::clamp(newDepth - reduction, 1, newDepth);
+
+				score = -search<false>(lmrDepth, ply+1, -alpha - 1, -alpha, ss+1, thread, limit);
 				// Re-search at normal depth
 				if (score > alpha)
 					score = -search<false>(newDepth, ply+1, -alpha - 1, -alpha, ss+1, thread, limit);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -569,7 +569,7 @@ namespace Search {
 
 				reduction /= 1024;
 
-				int lmrDepth = std::clamp(newDepth - reduction, 1, newDepth);
+				int lmrDepth = std::min(newDepth, std::max(1, newDepth - reduction));
 
 				score = -search<false>(lmrDepth, ply+1, -alpha - 1, -alpha, ss+1, thread, limit);
 				// Re-search at normal depth


### PR DESCRIPTION
Elo   | 0.47 +- 2.47 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.02 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 21648 W: 4532 L: 4503 D: 12613
Penta | [136, 2524, 5478, 2547, 139]
https://chess.n9x.co/test/1875/