### PR TITLE
LMR regardless of gives check

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -557,7 +557,7 @@ namespace Search {
 
 			int newDepth = depth - 1 + extension;
 			// Late Move Reduction
-			if (depth >= LMR_MIN_DEPTH() && moveCount > LMR_MIN_MOVECOUNT() && !thread.board.inCheck()){
+			if (depth >= LMR_MIN_DEPTH() && moveCount > LMR_MIN_MOVECOUNT()){
 				int reduction = LMR_BASE_SCALE() * lmrTable[isQuiet && move.typeOf() != Move::PROMOTION][depth][moveCount];
 
 				// Reduce more if not a PV node


### PR DESCRIPTION
Elo   | 2.68 +- 3.79 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.94 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 9596 W: 2123 L: 2049 D: 5424
Penta | [78, 1083, 2399, 1163, 75]
https://chess.n9x.co/test/1888/