### PR TITLE
Bad Noisy ordering

### DIFF
--- a/src/movepicker.cpp
+++ b/src/movepicker.cpp
@@ -14,7 +14,7 @@ void MovePicker::scoreMoves(Movelist &moves) {
 			if (move.typeOf() == Move::ENPASSANT)
 				to = PieceType::PAWN;
 			int score = thread->getCapthist(thread->board, move) + MVV_VALUES[to];
-			move.setScore(score - 800000 * !SEE(thread->board, move, -PawnValue));
+			move.setScore(score);
 		}
 		else {
 			move.setScore(thread->getQuietHistory(thread->board, move, ss));
@@ -55,7 +55,10 @@ Move MovePicker::nextMove() {
 				if (move == ttMove){
 					continue;
 				}
-				return move;
+				if (!SEE(thread->board, move, -move.score() / 4 + 15))
+					badNoises.add(move);
+				else
+					return move;
 			}
 			++stage;
 
@@ -76,6 +79,16 @@ Move MovePicker::nextMove() {
 		case QUIET:
 			while (currMove < movesList.size()) {
 				Move move = selectHighest(movesList);
+				if (move == ttMove)
+					continue;
+				return move;
+			}
+			currMove = 0;
+			++stage;
+
+		case BAD_NOISY:
+			while (currMove < badNoises.size()) {
+				Move move = selectHighest(badNoises);
 				if (move == ttMove)
 					continue;
 				return move;

--- a/src/movepicker.h
+++ b/src/movepicker.h
@@ -7,7 +7,7 @@
 #include "eval.h"
 
 enum class MPStage {
-    TTMOVE, GEN_NOISY, NOISY_GOOD, KILLER, GEN_QUIET, QUIET
+    TTMOVE, GEN_NOISY, NOISY_GOOD, KILLER, GEN_QUIET, QUIET, BAD_NOISY
 };
 
 inline MPStage operator++(MPStage& stage)
@@ -20,6 +20,7 @@ struct MovePicker {
 	Search::ThreadInfo *thread;
 	Search::Stack *ss;
 	Movelist movesList;
+	Movelist badNoises;
 	MPStage stage;
 	Move ttMove;
 	int currMove;


### PR DESCRIPTION
Elo   | 5.77 +- 3.98 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 9100 W: 2246 L: 2095 D: 4759
Penta | [69, 1050, 2174, 1175, 82]
https://chess.n9x.co/test/1970/