### PR TITLE
TT Depth Replacement Tweak

### DIFF
--- a/src/tt.h
+++ b/src/tt.h
@@ -49,7 +49,7 @@ struct TTEntry {
 		uint32_t key32 = static_cast<uint32_t>(key);
 		if (!moveIsNull(best) || key32 != this->zobrist)
 			this->move = best.move();
-		if (flag == TTFlag::EXACT || key32 != this->zobrist || depth > this->depth - 2 * isPV){
+		if (flag == TTFlag::EXACT || key32 != this->zobrist || depth + 4 + 2 * isPV > this->depth){
 			this->zobrist = key32;
 			this->score = score;
 			this->flag = flag;


### PR DESCRIPTION
Elo   | 9.56 +- 5.37 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4762 W: 1227 L: 1096 D: 2439
Penta | [33, 518, 1140, 665, 25]
https://chess.n9x.co/test/2093/