### PR TITLE
RFP Corrplexity

### DIFF
--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -29,17 +29,17 @@ TunableParam& addTunableParam(std::string name, int value, int min, int max, int
     return param;
 }
 
-int lmrConvolution(std::array<bool, 6> features) {
+int lmrConvolution(std::array<bool, LMR_ONE_COUNT> features) {
     int output = 0;
     int twoIndex = 0;
     int threeIndex = 0;
-    for (int i = 0; i < 6; i++) {
+    for (int i = 0; i < LMR_ONE_COUNT; i++) {
         output += LMR_ONE_PAIR[i] * features[i];
 
-        for (int j = i + 1; j < 6; j++) {
+        for (int j = i + 1; j < LMR_ONE_COUNT; j++) {
             output += LMR_TWO_PAIR[twoIndex] * (features[i] && features[j]);
 
-            for (int k = j + 1; k < 6; k++) {
+            for (int k = j + 1; k < LMR_ONE_COUNT; k++) {
                 output += LMR_THREE_PAIR[threeIndex] * (features[i] && features[j] && features[k]);
 
                 threeIndex++;

--- a/src/parameters.h
+++ b/src/parameters.h
@@ -57,7 +57,7 @@ extern std::array<int, LMR_THREE_COUNT> LMR_THREE_PAIR;
 
 std::list<TunableParam>& tunables();
 TunableParam& addTunableParam(std::string name, int value, int min, int max, int step);
-int lmrConvolution(std::array<bool, 6> features);
+int lmrConvolution(std::array<bool, LMR_ONE_COUNT> features);
 void printWeatherFactoryConfig();
 
 #define TUNABLE_PARAM(name, val, min, max, step)                                                                       \
@@ -84,6 +84,7 @@ TUNABLE_PARAM(HIST_MALUS_OFFSET, 169, 64, 768, 64);
 
 // Search Parameters
 TUNABLE_PARAM(RFP_SCALE, 76, 30, 100, 8);
+TUNABLE_PARAM(RFP_CORRPLEXITY_SCALE, 64, 16, 128, 5);
 
 TUNABLE_PARAM(RAZORING_SCALE, 300, 100, 350, 40);
 
@@ -102,9 +103,6 @@ TUNABLE_PARAM(LMR_BASE_QUIET, 137, -50, 200, 5);
 TUNABLE_PARAM(LMR_DIVISOR_QUIET, 275, 150, 350, 5);
 TUNABLE_PARAM(LMR_BASE_NOISY, 17, -50, 200, 5);
 TUNABLE_PARAM(LMR_DIVISOR_NOISY, 329, 150, 350, 5);
-// LMR Conditions
-TUNABLE_PARAM(LMR_MIN_DEPTH, 3, 1, 8, 1);
-TUNABLE_PARAM(LMR_BASE_MOVECOUNT, 2, 1, 10, 1);
 // Reduction Constants
 TUNABLE_PARAM(LMR_HIST_DIVISOR, 7952, 4096, 16385, 650);
 TUNABLE_PARAM(LMR_BASE_SCALE, 979, 256, 2048, 64)


### PR DESCRIPTION
Elo   | 1.18 +- 1.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 1.19 (-2.94, 2.94) [0.00, 3.00]
Games | N: 73486 W: 18038 L: 17788 D: 37660
Penta | [520, 8845, 17795, 9031, 552]
https://chess.n9x.co/test/2524/

LLR unchanged for 50k games. SPSA will figure it out, just merge