### PR TITLE
Cluster TT

### DIFF
--- a/src/datagen.cpp
+++ b/src/datagen.cpp
@@ -178,7 +178,10 @@ void runThread(int ti) {
             limit.start();
             thread->nodes = 0;
             thread->bestMove = Move::NO_MOVE;
+            
             int eval = Search::iterativeDeepening(board, *thread, limit, nullptr);
+            TT.incAge();
+            
             eval = std::min(std::max(-INFINITE, eval), INFINITE);
             eval = board.sideToMove() == Color::WHITE ? eval : -eval;
             Move m = thread->bestMove;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -205,7 +205,6 @@ void UCIGo(Searcher& searcher, Board& board, char* str) {
     Search::Limit limit = Search::Limit();
     ParseTimeControl(str, board.sideToMove(), limit);
 
-    searcher.TT.newSearch();
     searcher.startSearching(board, limit);
     // searcher.stop();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -205,6 +205,7 @@ void UCIGo(Searcher& searcher, Board& board, char* str) {
     Search::Limit limit = Search::Limit();
     ParseTimeControl(str, board.sideToMove(), limit);
 
+    searcher.TT.newSearch();
     searcher.startSearching(board, limit);
     // searcher.stop();
 }
@@ -280,10 +281,10 @@ void bench(Searcher& searcher) {
     TimeLimit timer = TimeLimit();
     searcher.printInfo = false;
     searcher.waitForSearchFinished();
+    searcher.reset();
     for (auto fen : fens) {
         timer.start();
         Board board(fen);
-        searcher.reset();
         Search::Limit limit = Search::Limit();
         limit.depth = (int64_t)BENCH_DEPTH;
         limit.movetime = 0;

--- a/src/parameters.h
+++ b/src/parameters.h
@@ -10,7 +10,7 @@
 #include <vector>
 
 #define MAX_PLY 125
-#define BENCH_DEPTH 12
+#define BENCH_DEPTH 13
 
 // Random big num
 #ifdef _MSC_VER

--- a/src/searcher.cpp
+++ b/src/searcher.cpp
@@ -65,6 +65,7 @@ void Search::ThreadInfo::startSearching() {
                 (currentScore > bestScore || !Search::isWin(bestScore)))
                 bestSearcher = thread.get();
         }
+        searcher->TT.incAge();
         std::cout << "\nbestmove "
                   << uci::moveToUci(bestSearcher->bestMove,
                                     searcher->board.chess960())

--- a/src/searcher.cpp
+++ b/src/searcher.cpp
@@ -38,7 +38,7 @@ void Search::ThreadInfo::startSearching() {
     nodes = 0;
     bestMove = Move::NO_MOVE;
     bestRootScore = -INFINITE;
-
+    
     Search::iterativeDeepening(searcher->board, *this, searcher->limit,
                                searcher);
 

--- a/src/searcher.h
+++ b/src/searcher.h
@@ -34,7 +34,6 @@ struct Searcher {
             waitForSearchFinished();
             this->board = board;
             this->limit = limit;
-            TT.incAge();
             for (auto& thread : threads) {
                 thread.get()->stopped = false;
                 std::lock_guard<std::mutex> lock(thread.get()->mutex);

--- a/src/searcher.h
+++ b/src/searcher.h
@@ -34,6 +34,7 @@ struct Searcher {
             waitForSearchFinished();
             this->board = board;
             this->limit = limit;
+            TT.incAge();
             for (auto& thread : threads) {
                 thread.get()->stopped = false;
                 std::lock_guard<std::mutex> lock(thread.get()->mutex);

--- a/src/searcher.h
+++ b/src/searcher.h
@@ -35,9 +35,9 @@ struct Searcher {
             this->board = board;
             this->limit = limit;
             for (auto& thread : threads) {
-                thread.get()->stopped = false;
+                thread.get()->stopped.store(false);
                 std::lock_guard<std::mutex> lock(thread.get()->mutex);
-                thread.get()->searching = true;
+                thread.get()->searching.store(true);
             }
 
             for (auto& thread : threads) {
@@ -51,7 +51,7 @@ struct Searcher {
         }
         void stopSearching() {
             for (auto& thread : threads) {
-                thread.get()->stopped = true;
+                thread.get()->stopped.store(true);
             }
         }
         void waitForSearchFinished() {
@@ -77,7 +77,7 @@ struct Searcher {
         uint64_t nodeCount() {
             uint64_t nodes = 0;
             for (auto& thread : threads) {
-                nodes += thread.get()->nodes;
+                nodes += thread.get()->loadNodes();
             }
             return nodes;
         }

--- a/src/tt.h
+++ b/src/tt.h
@@ -85,7 +85,7 @@ struct ProbedTTEntry {
     uint8_t bound;
 };
 
-struct TTCluster {
+struct alignas(32) TTCluster {
     TTEntry entries[ENTRY_COUNT];
     char padding[2];
 };
@@ -143,7 +143,7 @@ public:
     void store(uint64_t key, Move move, int score, int staticEval, uint8_t bound, int depth, int ply, bool pv) {
         uint16_t key16 = key & 0xFFFF;
         TTCluster& cluster = clusters[index(key)];
-        int currQuality = 32768;
+        int currQuality = INT_MAX;
         int replaceIdx = -1;
         for (int i = 0; i < ENTRY_COUNT; i++) {
             if (cluster.entries[i].key16 == key16) {
@@ -162,7 +162,7 @@ public:
         if (!moveIsNull(move) || replace.key16 != key16)
             replace.bestMove = move.move();
 
-        if (bound == TTFlag::EXACT || replace.key16 != key16 || depth >= replace.depth - 2 - 2 * pv || replace.gen() != currAge) {
+        if (bound == TTFlag::EXACT || replace.key16 != key16 || depth >= replace.depth - 4 - 2 * pv || replace.gen() != currAge) {
             replace.key16 = key16;
             replace.staticEval = staticEval;
             replace.depth = static_cast<uint8_t>(depth);

--- a/src/tt.h
+++ b/src/tt.h
@@ -70,11 +70,14 @@ struct TTEntry {
             ttkey keyShrink = static_cast<ttkey>(key);
             if (!moveIsNull(best) || keyShrink != this->zobrist)
                 this->move = best.move();
-            this->zobrist = keyShrink;
-            this->score = static_cast<int16_t>(score);
-            this->flags = uint8_t(flag + (isPV << 2)) | TT_GENERATION_COUNTER;
-            this->depth = depth;
-            this->staticEval = static_cast<int16_t>(eval);
+
+            if (flag == TTFlag::EXACT || keyShrink != this->zobrist || depth + 2 * isPV + 4 > this->depth) {
+                this->zobrist = keyShrink;
+                this->score = static_cast<int16_t>(score);
+                this->flags = uint8_t(flag + (isPV << 2)) | TT_GENERATION_COUNTER;
+                this->depth = depth;
+                this->staticEval = static_cast<int16_t>(eval);
+            }
         }
         bool getPV() {
             return this->flags & 0x4;
@@ -121,7 +124,7 @@ public:
 
     TTEntry* probe(uint64_t key, bool &tthit) {
         TTCluster* cluster = &table[index(key)];
-        uint64_t key16 = static_cast<ttkey>(key);
+        uint16_t key16 = static_cast<ttkey>(key);
 
         TTEntry* replace = &cluster->entries[0];
 

--- a/src/tt.h
+++ b/src/tt.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "external/chess.hpp"
+#include "eval.h"
 #include "parameters.h"
 #include "util.h"
 #include <bitset>
@@ -38,138 +39,180 @@ using namespace chess;
 
 enum TTFlag { NO_BOUND = 0, EXACT = 1, BETA_CUT = 2, FAIL_LOW = 3 };
 
-// Heavily based off PlentyChess
-constexpr int CLUSTER_SIZE = 3;
+// Heavily based off Stormphrax and Sirius
 
-constexpr int GENERATION_PADDING = 3;
-constexpr int GENERATION_DELTA = (1 << GENERATION_PADDING);
-constexpr int GENERATION_CYCLE = 255 + GENERATION_DELTA;
-constexpr int GENERATION_MASK = (0xFF << GENERATION_PADDING) & 0xFF;
+constexpr int ENTRY_COUNT = 3;
+constexpr size_t TT_ALIGNMENT = 64;
+static constexpr int GEN_CYCLE_LENGTH = 1 << 5;
 
-extern uint8_t TT_GENERATION_COUNTER;
 
-using ttkey = uint16_t;
-
+inline int storeScore(int score, int ply) {
+    if (std::abs(score) >= FOUND_MATE)
+        score += score < 0 ? -ply : ply;
+    return score;
+}
+inline int readScore(int score, int ply) {
+    if (std::abs(score) >= FOUND_MATE)
+        score += score < 0 ? ply : -ply;
+    return score;
+}
 
 struct TTEntry {
-        ttkey zobrist;
-        int16_t score;
-        int16_t staticEval;
-        uint16_t move;
-        uint8_t depth;
-        uint8_t flags;
-        TTEntry() {
-            this->zobrist = 0;
-            this->move = 0;
-            this->score = -32767;
-            this->flags = 0;
-            this->depth = 0;
-            this->staticEval = -32767;
-        }
-        void updateEntry(uint64_t key, chess::Move best, int score, int eval, uint8_t flag, uint8_t depth, bool isPV) {
-            ttkey keyShrink = static_cast<ttkey>(key);
-            if (!moveIsNull(best) || keyShrink != this->zobrist)
-                this->move = best.move();
+    uint16_t key16;
+    int16_t score;
+    int16_t staticEval;
+    uint16_t bestMove;
+    uint8_t depth;
+    uint8_t flags;
 
-            if (flag == TTFlag::EXACT || keyShrink != this->zobrist || depth + 2 * isPV + 4 > this->depth) {
-                this->zobrist = keyShrink;
-                this->score = static_cast<int16_t>(score);
-                this->flags = uint8_t(flag + (isPV << 2)) | TT_GENERATION_COUNTER;
-                this->depth = depth;
-                this->staticEval = static_cast<int16_t>(eval);
-            }
-        }
-        bool getPV() {
-            return this->flags & 0x4;
-        }
-        uint8_t getFlag() {
-            return this->flags & 0x3;
-        }
+    bool pv() { return (flags >> 2) & 1; }
+
+    uint8_t gen() { return flags >> 3; }
+
+    uint8_t bound() { return flags & 3; }
+
+    void setFlag(bool pv, uint8_t gen, uint8_t bound) {
+        flags = bound | (pv << 2) | (gen << 3);
+    }
+};
+
+struct ProbedTTEntry {
+    int score;
+    int staticEval;
+    uint16_t move;
+    int depth;
+    bool pv;
+    uint8_t bound;
 };
 
 struct TTCluster {
-    TTEntry entries[CLUSTER_SIZE];
+    TTEntry entries[ENTRY_COUNT];
     char padding[2];
 };
 
 class TTable {
-    TTCluster* table = nullptr;
-    size_t clusters = 0;
 
 public:
     TTable() {
         resize(16);
     }
     ~TTable() {
-        std::free(table);
-    }
-    void newSearch() {
-        TT_GENERATION_COUNTER += GENERATION_DELTA;
+        std::free(clusters);
     }
 
-    void resize(size_t mb) {
-        size_t clusterCount = mb * 1024 * 1024 / sizeof(TTCluster);
-        if (clusterCount == clusters)
+    void resize(int mb = 16) {
+        size_t clusterCount = static_cast<uint64_t>(mb) * 1024 * 1024 / sizeof(TTCluster);
+        if (clusterCount == size)
             return;
 
-        if (table)
-            std::free(table);
+        std::free(clusters);
 
-        clusters = clusterCount;
-        table = static_cast<TTCluster*>(alignedAlloc(sizeof(TTCluster), clusters * sizeof(TTCluster)));
-    }
-    size_t index(uint64_t key) {
-        return static_cast<std::uint64_t>((static_cast<u128>(key) * static_cast<u128>(clusters)) >> 64);
+        size = clusterCount;
+        clusters = static_cast<TTCluster*>(alignedAlloc(TT_ALIGNMENT, size * sizeof(TTCluster)));
+        currAge = 0;
     }
 
-    TTEntry* probe(uint64_t key, bool &tthit) {
-        TTCluster* cluster = &table[index(key)];
-        uint16_t key16 = static_cast<ttkey>(key);
+    bool probe(uint64_t key, int ply, ProbedTTEntry& ttData) {
+        size_t idx = index(key);
+        TTCluster& cluster = clusters[idx];
+        int entryIdx = -1;
+        uint16_t key16 = key & 0xFFFF;
 
-        TTEntry* replace = &cluster->entries[0];
-
-        for (int i = 0; i < CLUSTER_SIZE; i++) {
-            if (cluster->entries[i].zobrist == key16 || cluster->entries[i].zobrist == 0) {
-                cluster->entries[i].flags = static_cast<uint8_t>( TT_GENERATION_COUNTER | (cluster->entries[i].flags & (GENERATION_DELTA - 1)) );
-                tthit = cluster->entries[i].zobrist == key16;
-                return &cluster->entries[i];
-            }
-            if (i > 0) {
-                int replaceValue = replace->depth - ((GENERATION_CYCLE + TT_GENERATION_COUNTER - replace->flags) & GENERATION_MASK);
-                int entryValue = cluster->entries[i].depth - ((GENERATION_CYCLE + TT_GENERATION_COUNTER - cluster->entries[i].flags) & GENERATION_MASK);
-                if ((cluster->entries[i].zobrist == 0 && replace->zobrist != 0) || replaceValue > entryValue)
-                    replace = &cluster->entries[i];
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            if (cluster.entries[i].key16 == key16) {
+                entryIdx = i;
+                break;
             }
         }
-        tthit = false;
-        return replace;
+
+        if (entryIdx == -1)
+            return false;
+
+        auto entry = cluster.entries[entryIdx];
+
+        ttData.score = readScore(entry.score, ply);
+        ttData.staticEval = entry.staticEval;
+        ttData.move = entry.bestMove;
+        ttData.depth = entry.depth;
+        ttData.bound = entry.bound();
+        ttData.pv = entry.pv();
+
+        return true;
+    }
+
+    void store(uint64_t key, Move move, int score, int staticEval, uint8_t bound, int depth, int ply, bool pv) {
+        uint16_t key16 = key & 0xFFFF;
+        TTCluster& cluster = clusters[index(key)];
+        int currQuality = 32768;
+        int replaceIdx = -1;
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            if (cluster.entries[i].key16 == key16) {
+                replaceIdx = i;
+                break;
+            }
+
+            int entryQuality = quality(cluster.entries[i].gen(), cluster.entries[i].depth);
+            if (entryQuality < currQuality) {
+                currQuality = entryQuality;
+                replaceIdx = i;
+            }
+        }
+
+        TTEntry& replace = cluster.entries[replaceIdx];
+        if (!moveIsNull(move) || replace.key16 != key16)
+            replace.bestMove = move.move();
+
+        if (bound == TTFlag::EXACT || replace.key16 != key16 || depth >= replace.depth - 2 - 2 * pv || replace.gen() != currAge) {
+            replace.key16 = key16;
+            replace.staticEval = staticEval;
+            replace.depth = static_cast<uint8_t>(depth);
+            replace.score = static_cast<int16_t>(storeScore(score, ply));
+            replace.setFlag(pv, static_cast<uint8_t>(currAge), bound);
+        }
+    }
+
+    int quality(int age, int depth) {
+        int ageDiff = currAge - age;
+        if (ageDiff < 0) {
+            ageDiff += GEN_CYCLE_LENGTH;
+        }
+        return depth - 2 * ageDiff;
+    }
+
+    void incAge() {
+        currAge = (currAge + 1) % GEN_CYCLE_LENGTH;
+    }
+    void clear(int numThreads = 1) {
+        currAge = 0;
+        std::vector<std::jthread> threads;
+        threads.reserve(numThreads);
+        for (int i = 0; i < numThreads; i++) {
+            threads.emplace_back(
+                [i, this, numThreads]() {
+                    auto begin = clusters + size * i / numThreads;
+                    auto end = clusters + size * (i + 1) / numThreads;
+                    std::fill(begin, end, TTCluster{});
+                });
+        }
     }
 
     int hashfull() {
         int count = 0;
         for (int i = 0; i < 1000; i++) {
-            for (int j = 0; j < CLUSTER_SIZE; j++) {
-                if ((table[i].entries[j].flags & GENERATION_MASK) == TT_GENERATION_COUNTER && table[i].entries[j].zobrist != 0)
+            for (int j = 0; j < ENTRY_COUNT; j++) {
+                auto& entry = clusters[i].entries[j];
+                if (entry.bound() != TTFlag::NO_BOUND && entry.gen() == currAge)
                     count++;
             }
         }
-        return count / CLUSTER_SIZE;
+        return count / ENTRY_COUNT;
     }
-    void clear(int threadCount = 1) {
-        std::vector<std::thread> ts;
 
-        for (size_t thread = 0; thread < threadCount; thread++) {
-            size_t startCluster = thread * (clusters / threadCount);
-            size_t endCluster = thread == threadCount - 1 ? clusters : (thread + 1) * (clusters / threadCount);
-            ts.push_back(std::thread([this, startCluster, endCluster]() {
-                std::memset(static_cast<void*>(&table[startCluster]), 0, sizeof(TTCluster) * (endCluster - startCluster));
-            }));
-        }
-
-        for (auto& t : ts) {
-            t.join();
-        }
-
-        TT_GENERATION_COUNTER = 0;
+private:
+    TTCluster* clusters;
+    size_t size;
+    int currAge;
+    uint32_t index(uint64_t key) {
+        return static_cast<std::uint64_t>((static_cast<u128>(key) * static_cast<u128>(size)) >> 64);
     }
 };

--- a/src/tt.h
+++ b/src/tt.h
@@ -13,36 +13,58 @@
     #include <sys/mman.h>
 #endif
 
+
+inline void* alignedAlloc(size_t alignment, size_t requiredBytes) {
+    void* ptr;
+#if defined(__MINGW32__)
+    int offset = alignment - 1;
+    void* p = (void*)malloc(requiredBytes + offset);
+    ptr = (void*)(((size_t)(p)+offset) & ~(alignment - 1));
+#elif defined (__GNUC__)
+    ptr = std::aligned_alloc(alignment, requiredBytes);
+#else
+#error "Compiler not supported"
+#endif
+
+#if defined(__linux__)
+    madvise(ptr, requiredBytes, MADV_HUGEPAGE);
+#endif 
+
+    return ptr;
+}
+
+
 using namespace chess;
 
 enum TTFlag { NO_BOUND = 0, EXACT = 1, BETA_CUT = 2, FAIL_LOW = 3 };
 
+// Heavily based off PlentyChess
+constexpr int CLUSTER_SIZE = 3;
+
+constexpr int GENERATION_PADDING = 3;
+constexpr int GENERATION_DELTA = (1 << GENERATION_PADDING);
+constexpr int GENERATION_CYCLE = 255 + GENERATION_DELTA;
+constexpr int GENERATION_MASK = (0xFF << GENERATION_PADDING) & 0xFF;
+
+extern uint8_t TT_GENERATION_COUNTER;
+
 using ttkey = uint16_t;
+
+
 struct TTEntry {
         ttkey zobrist;
         int16_t score;
         int16_t staticEval;
         uint16_t move;
-        uint8_t flag;
         uint8_t depth;
-        bool isPV;
+        uint8_t flags;
         TTEntry() {
             this->zobrist = 0;
             this->move = 0;
             this->score = -32767;
-            this->flag = 0;
+            this->flags = 0;
             this->depth = 0;
             this->staticEval = -32767;
-            this->isPV = false;
-        }
-        TTEntry(uint64_t key, chess::Move best, int16_t score, int16_t eval, uint8_t flag, uint8_t depth, bool isPV) {
-            this->move = best.move();
-            this->zobrist = static_cast<ttkey>(key);
-            this->score = score;
-            this->flag = flag;
-            this->depth = depth;
-            this->staticEval = eval;
-            this->isPV = isPV;
         }
         void updateEntry(uint64_t key, chess::Move best, int score, int eval, uint8_t flag, uint8_t depth, bool isPV) {
             ttkey keyShrink = static_cast<ttkey>(key);
@@ -50,74 +72,99 @@ struct TTEntry {
                 this->move = best.move();
             this->zobrist = keyShrink;
             this->score = static_cast<int16_t>(score);
-            this->flag = flag;
+            this->flags = uint8_t(flag + (isPV << 2)) | TT_GENERATION_COUNTER;
             this->depth = depth;
             this->staticEval = static_cast<int16_t>(eval);
-            this->isPV = isPV;
+        }
+        bool getPV() {
+            return this->flags & 0x4;
+        }
+        uint8_t getFlag() {
+            return this->flags & 0x3;
         }
 };
 
-struct TTable {
-    private:
-        TTEntry* table;
+struct TTCluster {
+    TTEntry entries[CLUSTER_SIZE];
+    char padding[2];
+};
 
-    public:
-        uint64_t size;
+class TTable {
+    TTCluster* table = nullptr;
+    size_t clusters = 0;
 
-        TTable(uint64_t sizeMB = 16) {
-            table = nullptr;
-            resize(sizeMB);
+public:
+    TTable() {
+        resize(16);
+    }
+    ~TTable() {
+        std::free(table);
+    }
+    void newSearch() {
+        TT_GENERATION_COUNTER += GENERATION_DELTA;
+    }
+
+    void resize(size_t mb) {
+        size_t clusterCount = mb * 1024 * 1024 / sizeof(TTCluster);
+        if (clusterCount == clusters)
+            return;
+
+        if (table)
+            std::free(table);
+
+        clusters = clusterCount;
+        table = static_cast<TTCluster*>(alignedAlloc(sizeof(TTCluster), clusters * sizeof(TTCluster)));
+    }
+    size_t index(uint64_t key) {
+        return static_cast<std::uint64_t>((static_cast<u128>(key) * static_cast<u128>(clusters)) >> 64);
+    }
+
+    TTEntry* probe(uint64_t key, bool &tthit) {
+        TTCluster* cluster = &table[index(key)];
+        uint64_t key16 = static_cast<ttkey>(key);
+
+        TTEntry* replace = &cluster->entries[0];
+
+        for (int i = 0; i < CLUSTER_SIZE; i++) {
+            if (cluster->entries[i].zobrist == key16 || cluster->entries[i].zobrist == 0) {
+                cluster->entries[i].flags = static_cast<uint8_t>( TT_GENERATION_COUNTER | (cluster->entries[i].flags & (GENERATION_DELTA - 1)) );
+                tthit = cluster->entries[i].zobrist == key16;
+                return &cluster->entries[i];
+            }
+            if (i > 0) {
+                int replaceValue = replace->depth - ((GENERATION_CYCLE + TT_GENERATION_COUNTER - replace->flags) & GENERATION_MASK);
+                int entryValue = cluster->entries[i].depth - ((GENERATION_CYCLE + TT_GENERATION_COUNTER - cluster->entries[i].flags) & GENERATION_MASK);
+                if ((cluster->entries[i].zobrist == 0 && replace->zobrist != 0) || replaceValue > entryValue)
+                    replace = &cluster->entries[i];
+            }
         }
-        void clear(size_t threadCount = 1) {
-            std::vector<std::thread> threads;
+        tthit = false;
+        return replace;
+    }
 
-            auto clearTT = [&](size_t threadId) {
-                // The segment length is the number of entries each thread must clear
-                // To find where your thread should start (in entries), you can do threadId * segmentLength
-                // Converting segment length into the number of entries to clear can be done via length * bytes per
-                // entry
-
-                size_t start = (size * threadId) / threadCount;
-                size_t end = std::min((size * (threadId + 1)) / threadCount, size);
-
-                std::memset(table + start, 0, (end - start) * sizeof(TTEntry));
-            };
-
-            for (size_t thread = 1; thread < threadCount; thread++)
-                threads.emplace_back(clearTT, thread);
-
-            clearTT(0);
-
-            for (std::thread& t : threads)
-                if (t.joinable())
-                    t.join();
+    int hashfull() {
+        int count = 0;
+        for (int i = 0; i < 1000; i++) {
+            for (int j = 0; j < CLUSTER_SIZE; j++) {
+                if ((table[i].entries[j].flags & GENERATION_MASK) == TT_GENERATION_COUNTER && table[i].entries[j].zobrist != 0)
+                    count++;
+            }
         }
-        void resize(uint64_t MB) {
-            size = MB * 1024 * 1024 / sizeof(TTEntry);
-            if (table != nullptr)
-                std::free(table);
-            table = static_cast<TTEntry*>(std::malloc(size * sizeof(TTEntry)));
-        }
-        uint64_t index(uint64_t key) {
-            // return key % size;
-            return static_cast<std::uint64_t>((static_cast<u128>(key) * static_cast<u128>(size)) >> 64);
+        return count / CLUSTER_SIZE;
+    }
+    void clear(int threadCount = 1) {
+        std::vector<std::thread> ts;
+
+        for (size_t thread = 0; thread < threadCount; thread++) {
+            size_t startCluster = thread * (clusters / threadCount);
+            size_t endCluster = thread == threadCount - 1 ? clusters : (thread + 1) * (clusters / threadCount);
+            ts.push_back(std::thread([this, startCluster, endCluster]() {
+                std::memset(static_cast<void*>(&table[startCluster]), 0, sizeof(TTCluster) * (endCluster - startCluster));
+            }));
         }
 
-        TTEntry* getEntry(uint64_t key) {
-            return &table[index(key)];
+        for (auto& t : ts) {
+            t.join();
         }
-
-        TTEntry getEntryCopy(uint64_t key) {
-            return table[index(key)];
-        }
-
-        size_t hashfull() {
-            size_t samples = std::min((uint64_t)1000, size);
-            size_t hits = 0;
-            for (size_t sample = 0; sample < samples; sample++)
-                hits += table[sample].zobrist != 0;
-            size_t hash = (int)(hits / (double)samples * 1000);
-            assert(hash <= 1000);
-            return hash;
-        }
+    }
 };

--- a/src/tt.h
+++ b/src/tt.h
@@ -166,5 +166,7 @@ public:
         for (auto& t : ts) {
             t.join();
         }
+
+        TT_GENERATION_COUNTER = 0;
     }
 };


### PR DESCRIPTION
Elo   | 6.75 +- 3.50 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=1MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 3.00]
Games | N: 10920 W: 2701 L: 2489 D: 5730
Penta | [60, 1209, 2729, 1383, 79]
https://chess.n9x.co/test/2621/

SMP fix 2v1
Elo   | 72.67 +- 11.11 (95%)
Conf  | 8.0+0.08s Threads=2 Hash=32MB
Games | N: 1004 W: 344 L: 137 D: 523
Penta | [2, 41, 220, 226, 13]
https://chess.n9x.co/test/2635/

4v1
Elo   | 119.89 +- 13.18 (95%)
Conf  | 8.0+0.08s Threads=4 Hash=128MB
Games | N: 1000 W: 438 L: 106 D: 456
Penta | [6, 25, 145, 279, 45]
https://chess.n9x.co/test/2637/

2v2 nonreg against unfixed cluster tt
Elo   | 3.75 +- 4.18 (95%)
SPRT  | 8.0+0.08s Threads=2 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 7404 W: 1707 L: 1627 D: 4070
Penta | [44, 823, 1881, 917, 37]
https://chess.n9x.co/test/2639/