### PR TITLE
Complexity TM

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -646,7 +646,9 @@ namespace Search {
             ss->nonPawnKey[0] = resetNonPawnHash(threadInfo.board, Color::WHITE);
             ss->nonPawnKey[1] = resetNonPawnHash(threadInfo.board, Color::BLACK);
             ss->accumulator = baseAcc;
+            int eval = evaluate(threadInfo.board, ss->accumulator);
 
+            
             // Aspiration Windows
             if (depth >= MIN_ASP_WINDOW_DEPTH()) {
                 int delta = INITIAL_ASP_WINDOW();
@@ -712,7 +714,11 @@ namespace Search {
                 std::cout << " nodes " << nodecnt << " nps " << nodecnt / (limit.timer.elapsed() + 1) * 1000 << " time " << limit.timer.elapsed() << " pv ";
                 std::cout << pvss.str() << std::endl;
             }
-            if (limit.outOfTimeSoft(lastPV.moves[0], threadInfo.nodes))
+            // Time control (soft)
+            double complexity = 0;
+            if (!isMateScore(score))
+                complexity = 0.8 * std::abs(eval - score) * std::log(static_cast<double>(depth));
+            if (limit.outOfTimeSoft(lastPV.moves[0], threadInfo.nodes, complexity))
                 break;
         }
 

--- a/src/search.h
+++ b/src/search.h
@@ -137,13 +137,14 @@ namespace Search {
             bool outOfTime() {
                 return (enableClock && static_cast<int64_t>(timer.elapsed()) >= movetime);
             }
-            bool outOfTimeSoft(Move bestMove, uint64_t totalNodes) {
+            bool outOfTimeSoft(Move bestMove, uint64_t totalNodes, double complexity) {
                 if (!enableClock || softtime == 0)
                     return false;
 
                 double prop = static_cast<double>(nodeCounts[bestMove.move() & 4095]) / static_cast<double>(totalNodes);
                 double scale = (1.5 - prop) * 1.35;
-                return (static_cast<int64_t>(timer.elapsed()) >= softtime * scale);
+                double compScale = std::max(0.7 + std::clamp(complexity, 0.0, 200.0) / 400.0, 1.0);
+                return (static_cast<int64_t>(timer.elapsed()) >= softtime * scale * compScale);
             }
     };
 


### PR DESCRIPTION
Elo   | 4.54 +- 2.78 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 16666 W: 4253 L: 4035 D: 8378
Penta | [87, 1828, 4316, 1984, 118]
https://chess.n9x.co/test/2924/

Elo   | 6.63 +- 3.38 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 10008 W: 2456 L: 2265 D: 5287
Penta | [14, 1064, 2677, 1215, 34]
https://chess.n9x.co/test/2925/

I've not seen this before. The formulas were cooked up by vibes