### PR TITLE
Pawn History

### DIFF
--- a/src/parameters.h
+++ b/src/parameters.h
@@ -37,6 +37,7 @@ struct TunableParam {
 constexpr int16_t MAX_HISTORY = 16383;
 const int16_t DEFAULT_HISTORY = 0;
 constexpr int CORR_HIST_ENTRIES = 16384;
+constexpr int PAWN_HIST_ENTRIES = 1024;
 constexpr int MAX_CORR_HIST = 1024;
 // NNUE Parameters
 constexpr int16_t HL_N = 1024;


### PR DESCRIPTION
Elo   | 2.21 +- 1.72 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 46136 W: 11333 L: 11040 D: 23763
Penta | [279, 5485, 11264, 5744, 296]
https://chess.n9x.co/test/3154/