### PR TITLE
TT Corrected Eval

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -227,6 +227,13 @@ namespace Search {
                                 ? ttData.staticEval
                                 : evaluate(thread.board, ss->accumulator);
             eval = thread.correctStaticEval(ss, thread.board, rawStaticEval);
+            // If conditions met, use TT score as eval
+            if (ttHit && 
+                (ttData.bound == TTFlag::EXACT ||
+                    (ttData.bound == TTFlag::BETA_CUT && ttData.score >= eval) ||
+                    (ttData.bound == TTFlag::FAIL_LOW && ttData.score <= eval))) {
+                eval = ttData.score;
+            }
         }
 
         if (eval >= beta)
@@ -345,6 +352,14 @@ namespace Search {
                                 : evaluate(thread.board, ss->accumulator);
             ss->eval = ss->staticEval = thread.correctStaticEval(ss, thread.board, rawStaticEval);
             corrplexity = rawStaticEval - ss->staticEval;
+
+            // If conditions met, use TT score as eval
+            if (ttHit && 
+                (ttData.bound == TTFlag::EXACT ||
+                    (ttData.bound == TTFlag::BETA_CUT && ttData.score >= ss->eval) ||
+                    (ttData.bound == TTFlag::FAIL_LOW && ttData.score <= ss->eval))) {
+                ss->eval = ttData.score;
+            }
         }
         // Improving heurstic
         // We are better than 2 plies ago


### PR DESCRIPTION
Elo   | 2.87 +- 2.08 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
Games | N: 31198 W: 7614 L: 7356 D: 16228
Penta | [175, 3677, 7655, 3899, 193]
https://chess.n9x.co/test/3784/

For some reason, this seems to ruin thread scaling. Will look into