### PR TITLE
TT Prefetch

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -42,6 +42,23 @@ namespace Search {
                          1024);
     }
 
+    inline uint64_t prefetchKey(Board& board, Move move) {
+        Piece movingPiece = board.at(move.from());
+        Piece captured = board.at(move.to());
+        uint64_t key = board.hash();
+
+        // Update Zobrist
+        key ^= Zobrist::piece(movingPiece, move.from());
+        key ^= Zobrist::piece(movingPiece, move.to());
+
+        if (captured != Piece::NONE)
+            key ^= Zobrist::piece(captured, move.to());
+
+        key ^= Zobrist::sideToMove();
+        return key;
+
+    }
+
     struct PVList {
             std::array<chess::Move, MAX_PLY> moves;
             uint32_t length;

--- a/src/tt.h
+++ b/src/tt.h
@@ -112,6 +112,10 @@ public:
         currAge = 0;
     }
 
+    void prefetch(uint64_t key) {
+        __builtin_prefetch(&clusters[index(key)]);
+    }
+
     bool probe(uint64_t key, int ply, ProbedTTEntry& ttData) {
         size_t idx = index(key);
         TTCluster& cluster = clusters[idx];


### PR DESCRIPTION
Elo   | 14.27 +- 5.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 4678 W: 1217 L: 1025 D: 2436
Penta | [24, 452, 1207, 620, 36]
https://chess.n9x.co/test/4012/
Fake speedup elo