### PR TITLE
RFP Depth 8 

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -369,7 +369,7 @@ namespace Search {
             int rfpMargin = RFP_SCALE() * (depth - improving);
             rfpMargin += corrplexity * RFP_CORRPLEXITY_SCALE() / 128;
 
-            if (depth <= 6 && ss->eval - rfpMargin >= beta)
+            if (depth <= 8 && ss->eval - rfpMargin >= beta)
                 return ss->eval;
 
             if (depth <= 4 && std::abs(alpha) < 2000 && ss->staticEval + RAZORING_SCALE() * depth <= alpha) {


### PR DESCRIPTION
Elo   | 2.27 +- 1.75 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 42962 W: 10333 L: 10052 D: 22577
Penta | [217, 5093, 10590, 5354, 227]
https://chess.n9x.co/test/3719/