### PR TITLE
LMR Corrplexity

### DIFF
--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -11,13 +11,9 @@
 using namespace chess;
 
 // LMR
-std::array<int, LMR_ONE_COUNT> LMR_ONE_PAIR = {66, 978, -835, 1797, -818, -155, 851};
-std::array<int, LMR_TWO_COUNT> LMR_TWO_PAIR = {-84, -175, 88, 166, -53, 153, -234, 220, -24, -31,
-                                                128, -21, -198, 38, -103, 9, -160, 83, 353, -206, 76};
-std::array<int, LMR_THREE_COUNT> LMR_THREE_PAIR = {-181, -108, -143, -189, -219, 187, -180, 158, 10, -10,
-                                                    228, -84, 123, 76, -35, -47, 142, -116, 22, 162,
-                                                    -57, -145, 207, 22, -37, -286, 137, 233, -131, 39,
-                                                    2, 169, 19, 87, -85};
+std::array<int, LMR_ONE_COUNT> LMR_ONE_PAIR = {66, 978, -835, 1797, -818, -155, 851, -1024};
+std::array<int, LMR_TWO_COUNT> LMR_TWO_PAIR = {-84, -175, 88, 166, -53, 153, 0, -234, 220, -24, -31, 128, 0, -21, -198, 38, -103, 0, 9, -160, 83, 0, 353, -206, 0, 76, 0, 0};
+std::array<int, LMR_THREE_COUNT> LMR_THREE_PAIR = {-181, -108, -143, -189, -219, 0, 187, -180, 158, 10, 0, -10, 228, -84, 0, 123, 76, 0, -35, 0, 0, -47, 142, -116, 22, 0, 162, -57, -145, 0, 207, 22, 0, -37, 0, 0, -286, 137, 233, 0, -131, 39, 0, 2, 0, 0, 169, 19, 0, 87, 0, 0, -85, 0, 0, 0};
 // Code from Sirius
 // https://github.com/mcthouacbb/Sirius/blob/b80a3d18461d97e94ba3102bc3fb422db66f4e7d/Sirius/src/search_params.cpp#L17C1-L29C2
 std::list<TunableParam>& tunables() {

--- a/src/parameters.h
+++ b/src/parameters.h
@@ -60,8 +60,8 @@ const std::array<int, 64> BUCKET_LAYOUT = {
 };
 
 // Factorized LMR arrays
-// {isQuiet, !isPV, improving, cutnode, ttpv, tthit, failhigh > 2}
-const int LMR_ONE_COUNT = 7;
+// {isQuiet, !isPV, improving, cutnode, ttpv, tthit, failhigh > 2, corr > x}
+const int LMR_ONE_COUNT = 8;
 const int LMR_TWO_COUNT = LMR_ONE_COUNT * (LMR_ONE_COUNT - 1) / 2;
 const int LMR_THREE_COUNT = LMR_ONE_COUNT * (LMR_ONE_COUNT - 1) * (LMR_ONE_COUNT - 2) / 6;
 extern std::array<int, LMR_ONE_COUNT> LMR_ONE_PAIR;
@@ -143,6 +143,7 @@ TUNABLE_PARAM(LMR_DIVISOR_NOISY, 333, 150, 350, 5);
 // Reduction Constants
 TUNABLE_PARAM(LMR_HIST_DIVISOR, 8922, 4096, 16385, 650);
 TUNABLE_PARAM(LMR_BASE_SCALE, 1058, 256, 2048, 64)
+TUNABLE_PARAM(LMR_CORR_MARGIN, 69, 32, 256, 9);
 // Deeper/Shallower
 TUNABLE_PARAM(LMR_DEEPER_BASE, 36, 16, 64, 4)
 TUNABLE_PARAM(LMR_DEEPER_SCALE, 3, 3, 12, 1)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -540,15 +540,15 @@ namespace Search {
                 // | to 3 way interactions between them. For example, a two way  |
                 // | interaction would be two_way_table[i] * (x && y), three     |
                 // | way would be three_way_table[j] * (x && y && z) etc         |
-                // | For the 6 variables here, that gives us a one way           |
+                // | For example 6 variables, that gives us a one way           |
                 // | table of 6, two table of 6x5/2=15, and three way of         |
                 // | 6x5x3/3!=20. Thanks to AGE for this idea                    |
                 // ---------------------------------------------------------------
-                reduction += lmrConvolution({isQuiet, !isPV, improving, cutnode, ttPV, ttHit, ((ss + 1)->failHighs > 2)});
+                reduction += lmrConvolution({isQuiet, !isPV, improving, cutnode, ttPV, ttHit, ((ss + 1)->failHighs > 2), corrplexity > LMR_CORR_MARGIN()});
                 // Reduce less if good history
                 reduction -= 1024 * ss->historyScore / LMR_HIST_DIVISOR();
 
-                reduction -= 1024 * (corrplexity > 69);
+                //reduction -= 1024 * (corrplexity > 69);
                 
                 reduction /= 1024;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -547,6 +547,8 @@ namespace Search {
                 reduction += lmrConvolution({isQuiet, !isPV, improving, cutnode, ttPV, ttHit, ((ss + 1)->failHighs > 2)});
                 // Reduce less if good history
                 reduction -= 1024 * ss->historyScore / LMR_HIST_DIVISOR();
+
+                reduction -= 1024 * (corrplexity > 69);
                 
                 reduction /= 1024;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -547,8 +547,6 @@ namespace Search {
                 reduction += lmrConvolution({isQuiet, !isPV, improving, cutnode, ttPV, ttHit, ((ss + 1)->failHighs > 2), corrplexity > LMR_CORR_MARGIN()});
                 // Reduce less if good history
                 reduction -= 1024 * ss->historyScore / LMR_HIST_DIVISOR();
-
-                //reduction -= 1024 * (corrplexity > 69);
                 
                 reduction /= 1024;
 


### PR DESCRIPTION
Elo   | 4.09 +- 2.64 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 19732 W: 4849 L: 4617 D: 10266
Penta | [120, 2317, 4764, 2541, 124]
https://kelseyde.pythonanywhere.com/test/1362/