### PR TITLE
Depth Extension in SE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,12 @@ ifndef EVALFILE
     NO_EVALFILE_SET = true
 endif
 
+ifeq ($(OS),Windows_NT)
+    STACK_FLAGS := -Wl,/STACK:8388608
+else
+    STACK_FLAGS :=
+endif
+
 CXXFLAGS := -O3 $(ARCH) -fno-finite-math-only -funroll-loops -flto -fuse-ld=lld -std=c++20 -DNDEBUG -static -pthread -DEVALFILE=\"$(EVALFILE)\"
 
 ifdef NO_EVALFILE_SET
@@ -44,7 +50,7 @@ ifndef EXE
 endif
 
 $(EXE): $(EVALFILE) $(SOURCES) 
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(SOURCES) -o $@
+	$(CXX) $(CXXFLAGS) $(STACK_FLAGS) $(LDFLAGS) $(SOURCES) -o $@
 
 native: $(EXE)
 

--- a/src/parameters.h
+++ b/src/parameters.h
@@ -9,7 +9,7 @@
 #include <sstream>
 #include <vector>
 
-#define MAX_PLY 125
+const int MAX_PLY = 125;
 #define BENCH_DEPTH 13
 
 // Random big num

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -306,7 +306,6 @@ namespace Search {
         if (depth <= 0) {
             return qsearch<isPV>(ply, alpha, beta, ss, thread, limit);
         }
-
         // Terminal Conditions (and checkmate)
         if (!root) {
             if (thread.board.isRepetition(1) || thread.board.isHalfMoveDraw())


### PR DESCRIPTION
Elo   | 4.04 +- 2.60 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 19694 W: 4835 L: 4606 D: 10253
Penta | [98, 2292, 4860, 2477, 120]
https://kelseyde.pythonanywhere.com/test/1418/
also increased windows stack size to prevent limit being hit at high plies