### PR TITLE
Net net "Comet Azur"

### DIFF
--- a/network.txt
+++ b/network.txt
@@ -1,1 +1,1 @@
-crucible-knight
+comet-azur

--- a/src/parameters.h
+++ b/src/parameters.h
@@ -45,18 +45,18 @@ constexpr int16_t QA = 255;
 constexpr int16_t QB = 64;
 constexpr int16_t NNUE_SCALE = 400;
 constexpr int OUTPUT_BUCKETS = 8;
-constexpr int INPUT_BUCKETS = 4;
+constexpr int INPUT_BUCKETS = 6;
 const bool HORIZONTAL_MIRROR = true;
 
 const std::array<int, 64> BUCKET_LAYOUT = {
     0, 0, 1, 1, 1, 1, 0, 0,
-    2, 2, 2, 2, 2, 2, 2, 2,
-    3, 3, 3, 3, 3, 3, 3, 3,
-    3, 3, 3, 3, 3, 3, 3, 3,
-    3, 3, 3, 3, 3, 3, 3, 3,
-    3, 3, 3, 3, 3, 3, 3, 3,
-    3, 3, 3, 3, 3, 3, 3, 3,
-    3, 3, 3, 3, 3, 3, 3, 3,
+    2, 2, 3, 3, 3, 3, 2, 2, 
+    4, 4, 4, 4, 4, 4, 4, 4,
+    4, 4, 4, 4, 4, 4, 4, 4,
+    4, 4, 4, 4, 4, 4, 4, 4,
+    5, 5, 5, 5, 5, 5, 5, 5,
+    5, 5, 5, 5, 5, 5, 5, 5,
+    5, 5, 5, 5, 5, 5, 5, 5,
 };
 
 // Factorized LMR arrays


### PR DESCRIPTION
6 king buckets
Elo   | 11.37 +- 4.59 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 3.00]
Games | N: 5868 W: 1564 L: 1372 D: 2932
Penta | [20, 611, 1478, 807, 18]
https://chess.n9x.co/test/4119/

Fine tune at 0.8 wdl instead of 0.7
Elo   | 7.16 +- 3.59 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 9658 W: 2503 L: 2304 D: 4851
Penta | [23, 1102, 2384, 1293, 27]
https://chess.n9x.co/test/4170/